### PR TITLE
Fixing missing post_policies variable

### DIFF
--- a/01_setup/04_Update_IAM_Roles_And_Policies.ipynb
+++ b/01_setup/04_Update_IAM_Roles_And_Policies.ipynb
@@ -76,6 +76,7 @@
    "outputs": [],
    "source": [
     "admin = False\n",
+    "post_policies = iam.list_attached_role_policies(RoleName=role_name)['AttachedPolicies']",
     "\n",
     "for post_policy in post_policies:\n",
     "    if post_policy['PolicyName'] == 'AdministratorAccess':\n",


### PR DESCRIPTION
the post_policies var was missing, and not populated early in the script when the notebook checks for IAMFullAccess, this fixes this.