### PR TITLE
Remove invalid pip version check flag

### DIFF
--- a/00_quickstart/01_Setup_Dependencies.ipynb
+++ b/00_quickstart/01_Setup_Dependencies.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!conda install --disable-pip-version-check -y pytorch==1.6.0 -c pytorch"
+    "!conda install -y pytorch==1.6.0 -c pytorch"
    ]
   },
   {


### PR DESCRIPTION
With the `--disable-pip-version-check` flag set, `conda` will exit with `ERROR`.  This PR removes the flag, which installs PyTorch as expected.